### PR TITLE
Fix icon consistency with the original javascript implementation

### DIFF
--- a/lib/src/utilities.dart
+++ b/lib/src/utilities.dart
@@ -13,8 +13,13 @@ List<Color> defaultBoringAvatarsColors = [
 ];
 
 int getNumber(String name) {
-  if (name.codeUnits.isEmpty) return 0;
-  return name.codeUnits.reduce((a, b) => a + b);
+  if (name.isEmpty) return 0;
+
+  int hash = name.codeUnits.reduce((hash, character) {
+    return (((hash << 5) - hash) + character) & 0xFFFFFFFF; // Converted to 32bit integer
+  });
+
+  return hash.toSigned(32).abs();
 }
 
 int getModulus(int num, int max) => num % max;


### PR DESCRIPTION
This PR fixes utilities.getNumber to generate the same output as the getHash function from the original. This way the icons created by this flutter implementation are similar to icons of the javascript-based original. This is useful in cases where both are used side-by-side in an ecosystem consisting of a flutter app and a website.

Since this PR produces different icons, it may be considered a major version change. Perhaps it is better to offer both options, defaulting to the old behavior. That would be a bigger change.

For reference and ease of reviewing, here's the original javascript has function:
https://github.com/boringdesigners/boring-avatars/blob/master/src/lib/utilities.js#L1C1-L9C2
